### PR TITLE
allow custom hidden class - fixes #10

### DIFF
--- a/dist/jquery.cssSelect.js
+++ b/dist/jquery.cssSelect.js
@@ -23,26 +23,27 @@
       });
     }
 
+    // keep a reference to the original <select>:
+    var $originalSelect = this;
+
+    options = $.extend({
+      classRoot: 'select ' + 'name-' + $originalSelect.attr('name'),
+      hiddenClass: 'hidden',
+      // 'decorator' options need to return a DOM string that jQuery can use.
+      liDecorator: function(){ return '';}
+    }, options);
+
     // flag to check if the mouse is in the dropdown ul container
     var mouseInContainer = false;
 
-    // keep a reference to the original <select>:
-    var $originalSelect = this;
     // 'hide' it:
-    $originalSelect.addClass('hidden');
+    $originalSelect.addClass(options.hiddenClass);
 
     var KEYCODES = {
       UP: 38,
       DOWN: 40,
       RETURN: 13
     };
-
-    options = $.extend({
-      classRoot: 'select ' + 'name-' + $originalSelect.attr('name'),
-      // 'decorator' options need to return a DOM string that jQuery can use.
-      liDecorator: function(){ return '';},
-      additionalItems: []
-    }, options);
 
     // create a new 'select' that we'll
     // be appending list items to:

--- a/dist/jquery.cssSelect.js
+++ b/dist/jquery.cssSelect.js
@@ -27,6 +27,7 @@
     var $originalSelect = this;
 
     options = $.extend({
+      additionalItems: [],
       classRoot: 'select ' + 'name-' + $originalSelect.attr('name'),
       hiddenClass: 'hidden',
       // 'decorator' options need to return a DOM string that jQuery can use.


### PR DESCRIPTION
Fixes #10 by allowing use of a custom hidden class.

Client code should either define `hidden` or use a different custom class such as `visuallyhidden` - in either case the class should ensure that the &lt;select&gt; element remains on the page and focusable by the native focus event.
